### PR TITLE
Fixed handling of skills

### DIFF
--- a/src/account-server/storage.cpp
+++ b/src/account-server/storage.cpp
@@ -429,26 +429,26 @@ Character *Storage::getCharacterBySQL(Account *owner)
         s.clear();
         s.str("");
 
-        // Load the skills of the char from CHAR_SKILLS_TBL_NAME
-        s << "select status_id, status_time FROM "
-          << CHAR_STATUS_EFFECTS_TBL_NAME
+        // Load skills.
+        s << "SELECT skill_id, skill_exp "
+          << "FROM " << CHAR_SKILLS_TBL_NAME
           << " WHERE char_id = " << character->getDatabaseID();
 
         const dal::RecordSet &skillInfo = mDb->execSql(s.str());
         if (!skillInfo.isEmpty())
         {
             const unsigned int nRows = skillInfo.rows();
-            for (unsigned int row = 0; row < nRows; row++)
+            for (unsigned int row = 0; row < nRows; ++row)
             {
-                character->setExperience(
-                    toUint(skillInfo(row, 0)),  // Skill Id
-                    toUint(skillInfo(row, 1))); // Experience
+                unsigned int id = toUint(skillInfo(row, 0));
+                character->setExperience(id, toInt(skillInfo(row, 1)));
             }
         }
 
-        // Load the status effect
         s.clear();
         s.str("");
+
+        // Load the status effects
         s << "select status_id, status_time FROM "
           << CHAR_STATUS_EFFECTS_TBL_NAME
           << " WHERE char_id = " << character->getDatabaseID();

--- a/src/common/manaserv_protocol.h
+++ b/src/common/manaserv_protocol.h
@@ -118,7 +118,7 @@ enum {
     GPMSG_INVENTORY_FULL           = 0x0121, // W inventory slot count { W slot, W itemId, W amount }, { W equip slot, W item Id, W item Instance}*
     GPMSG_EQUIP                    = 0x0122, // W item Id, W equip slot type count //{ W equip slot, W capacity used}*//<- When equipping, //{ W item instance, W 0}*//<- When unequipping
     GPMSG_PLAYER_ATTRIBUTE_CHANGE  = 0x0130, // { W attribute, D base value (in 1/256ths), D modified value (in 1/256ths)}*
-    GPMSG_PLAYER_EXP_CHANGE        = 0x0140, // { W skill, D exp got, D exp needed }*
+    GPMSG_PLAYER_EXP_CHANGE        = 0x0140, // { W skill, D exp got, D exp needed, W skill level }*
     GPMSG_LEVELUP                  = 0x0150, // W new level, W character points, W correction points
     GPMSG_LEVEL_PROGRESS           = 0x0151, // B percent completed to next levelup
     PGMSG_RAISE_ATTRIBUTE          = 0x0160, // W attribute

--- a/src/game-server/character.cpp
+++ b/src/game-server/character.cpp
@@ -474,6 +474,7 @@ void Character::sendStatus()
         expMsg.writeInt16(skill);
         expMsg.writeInt32(getExpGot(skill));
         expMsg.writeInt32(getExpNeeded(skill));
+        expMsg.writeInt16(levelForExp(getExperience(skill)));
     }
     if (expMsg.getLength() > 2) gameHandler->sendTo(this, expMsg);
     mModifiedExperience.clear();
@@ -639,10 +640,6 @@ void Character::receiveExperience(int skill, int experience, int optimalLevel)
     // Inform account server
     if (newExp != oldExp)
         accountHandler->updateExperience(getDatabaseID(), skill, newExp);
-
-    // Check for skill levelup
-    if (Character::levelForExp(newExp) >= Character::levelForExp(oldExp))
-        updateDerivedAttributes(skill);
 
     mRecalculateLevel = true;
 }

--- a/src/game-server/gamehandler.cpp
+++ b/src/game-server/gamehandler.cpp
@@ -378,11 +378,6 @@ void GameHandler::tokenMatched(GameClient *computer, Character *character)
     // Force sending the whole character to the client.
     Inventory(character).sendFull();
     character->modifiedAllAttribute();
-    std::map<int, int>::const_iterator skill_it;
-    for (skill_it = character->getSkillBegin(); skill_it != character->getSkillEnd(); skill_it++)
-    {
-        character->updateDerivedAttributes(skill_it->first);
-    }
 }
 
 void GameHandler::deletePendingClient(GameClient *computer)


### PR DESCRIPTION
- Removed possibility of skills getting mixed with attributes
  - Made the server sending the level of the current skill on exp change
    (currently the client could calculate it itself, but it allows more
    flexibillity in future this way)
  - Fixed reading of skills out of the database
    (for some reason the status effects were added as skills)

*\* Needs clientside patch as well (coming soon) **
