### PR TITLE
Fixed issues with removing attribute modifiers

### DIFF
--- a/src/game-server/attribute.cpp
+++ b/src/game-server/attribute.cpp
@@ -157,7 +157,7 @@ bool AttributeModifiersEffect::remove(double value, unsigned int id,
 
         /* If this is stackable, we need to update for every modifier affected */
         if (mStackableType == Stackable)
-            updateMod();
+            updateMod(value);
 
         ret = true;
         if (!id)
@@ -283,9 +283,10 @@ bool Attribute::remove(double value, unsigned int layer,
     assert(mMods.size() > layer);
     if (mMods.at(layer)->remove(value, lvl, fullcheck))
     {
-        while (++layer < mMods.size())
-           if (!mMods.at(layer)->recalculateModifiedValue(
-                         mMods.at(layer - 1)->getCachedModifiedValue()))
+        for (; layer < mMods.size(); ++layer)
+            if (!mMods.at(layer)->recalculateModifiedValue(
+                        layer ? mMods.at(layer - 1)->getCachedModifiedValue()
+                              : mBase))
                return false;
         return true;
     }


### PR DESCRIPTION
- AttributeModifiersEffect::remove was not calling updateMod with the 'value' parameter, causing it to have no effect at all for Stackable modifiers.
- The cached value of the changed modifier effect was not being recalculated when removing modifiers, because it started one layer too high (there's an inconsistency here: AttributeModifiersEffect::add updates this cached value while AttributeModifiersEffect::remove doesn't).
