### PR TITLE
Set the current map when executing being callbacks

### DIFF
--- a/src/scripting/luascript.cpp
+++ b/src/scripting/luascript.cpp
@@ -241,6 +241,7 @@ void LuaScript::processDeathEvent(Being *entity)
 {
     if (mDeathNotificationCallback.isValid())
     {
+        setMap(entity->getMap());
         prepare(mDeathNotificationCallback);
         push(entity);
         //TODO: get and push a list of creatures who contributed to killing the
@@ -253,6 +254,7 @@ void LuaScript::processRemoveEvent(Entity *entity)
 {
     if (mRemoveNotificationCallback.isValid())
     {
+        setMap(entity->getMap());
         prepare(mRemoveNotificationCallback);
         push(entity);
         //TODO: get and push a list of creatures who contributed to killing the


### PR DESCRIPTION
The on_death and on_remove callbacks where not being executed in the context of any map. Now they execute in the context of the map of the being.
