### PR TITLE
Monsters no longer load their script files

### DIFF
--- a/example/monsters.xml
+++ b/example/monsters.xml
@@ -89,7 +89,6 @@ exp<TAG>:                 Tells how much experience point a monster is giving up
             range="32"
             animation="attack"
             />
-            <script>testmonster.lua</script> <!-- only Proof of Concept-->
     </monster>
 
     <monster id="2" name="Scorpion">

--- a/src/game-server/monster.cpp
+++ b/src/game-server/monster.cpp
@@ -117,9 +117,6 @@ Monster::Monster(MonsterClass *specy):
     {
         addAttack(*it);
     }
-
-    // Load default script
-    loadScript(specy->getScript());
 }
 
 Monster::~Monster()
@@ -285,25 +282,6 @@ void Monster::processAttack(Attack &attack)
         script->push(mTarget);
         script->push(hit);
         script->execute();
-    }
-}
-
-void Monster::loadScript(const std::string &scriptName)
-{
-    if (scriptName.length() == 0)
-        return;
-
-    std::stringstream filename;
-    filename << "scripts/monster/" << scriptName;
-    if (ResourceManager::exists(filename.str()))
-    {
-        LOG_INFO("Loading monster script: " << filename.str());
-        ScriptManager::currentState()->loadFile(filename.str());
-    }
-    else
-    {
-        LOG_WARN("Could not find script file \""
-                 << filename.str() << "\" for monster");
     }
 }
 

--- a/src/game-server/monster.h
+++ b/src/game-server/monster.h
@@ -202,12 +202,6 @@ class MonsterClass
 
         double getVulnerability(Element element) const;
 
-        /** sets the script file for the monster */
-        void setScript(const std::string &filename) { mScript = filename; }
-
-        /** Returns script filename */
-        const std::string &getScript() const { return mScript; }
-
         void setUpdateCallback(Script *script)
         { script->assignCallback(mUpdateCallback); }
 
@@ -239,7 +233,6 @@ class MonsterClass
         int mOptimalLevel;
         std::vector<AttackInfo *> mAttacks;
         Vulnerabilities mVulnerabilities;
-        std::string mScript;
 
         /**
          * A reference to the script function that is called each update.
@@ -301,11 +294,6 @@ class Monster : public Being
          * Performs an attack
          */
         virtual void processAttack(Attack &attack);
-
-        /**
-         * Loads a script file for this monster
-         */
-        void loadScript(const std::string &scriptName);
 
         /**
          * Kills the being.

--- a/src/game-server/monstermanager.cpp
+++ b/src/game-server/monstermanager.cpp
@@ -258,12 +258,6 @@ void MonsterManager::initialize()
                 }
 
             }
-            else if (xmlStrEqual(subnode->name, BAD_CAST "script"))
-            {
-                xmlChar *filename = subnode->xmlChildrenNode->content;
-                std::string val = (char *)filename;
-                monster->setScript(val);
-            }
             else if (xmlStrEqual(subnode->name, BAD_CAST "vulnerability"))
             {
                 Element element = elementFromString(


### PR DESCRIPTION
Before monsters loaded their script file on _each_ spawn.
This is rather wrong since the script state keeps growing for each monster.
However all of this was unnessecary since the main.lua can simply require
the script file.

If you do not want to spam the main.lua (or any other file) with all the
requires: I guess we can add script binds to iterate over all monsters and
add some custom properties to the monsters.xml (See Mana-Mantis #356)
