### PR TITLE
Added possibility to reserve maps

### DIFF
--- a/accountserver.cbp
+++ b/accountserver.cbp
@@ -148,6 +148,8 @@
 		<Unit filename="src/account-server/character.cpp" />
 		<Unit filename="src/account-server/character.h" />
 		<Unit filename="src/account-server/main-account.cpp" />
+		<Unit filename="src/account-server/mapmanager.cpp" />
+		<Unit filename="src/account-server/mapmanager.h" />
 		<Unit filename="src/account-server/serverhandler.cpp" />
 		<Unit filename="src/account-server/serverhandler.h" />
 		<Unit filename="src/account-server/storage.cpp" />

--- a/docs/manaserv.xml.example
+++ b/docs/manaserv.xml.example
@@ -161,6 +161,15 @@
  <!-- needed to set when hosting behind router or in situations
       where you cannot bind the server to the public url -->
  <!-- <option name="net_publicGameHost" value="mydomain.org"/> -->
+ 
+ <!--
+ Usually the first game server activates all maps. To prevent this you need to
+ set a name for the server and set this name in the maps.xml (see documentation
+ there).
+ -->
+ <!--
+ <option name="net_gameServerName" value="myServer" />
+ -->
 
  <!--
  Update host url: E.g.: "http://updates.manasource.org/"

--- a/example/maps.xml
+++ b/example/maps.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <maps>
+    <!--
+         id: unique id of map(> 0)
+         name: the name of the maps (without .tmx extension)
+         [optional] servername: the name of the server that should run this map
+    -->
     <map id="1" name="desert" />
 </maps>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -153,6 +153,8 @@ SET(SRCS_MANASERVACCOUNT
     account-server/character.h
     account-server/character.cpp
     account-server/flooritem.h
+    account-server/mapmanager.h
+    account-server/mapmanager.cpp
     account-server/serverhandler.h
     account-server/serverhandler.cpp
     account-server/storage.h

--- a/src/account-server/mapmanager.cpp
+++ b/src/account-server/mapmanager.cpp
@@ -1,0 +1,61 @@
+/*
+ *  The Mana Server
+ *  Copyright (C) 2004-2010  The Mana World Development Team
+ *  Copyright (C) 2010-2013  The Mana Development Team
+ *
+ *  This file is part of The Mana Server.
+ *
+ *  The Mana Server is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  any later version.
+ *
+ *  The Mana Server is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with The Mana Server.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "account-server/mapmanager.h"
+
+#include "utils/logger.h"
+#include "utils/xml.h"
+
+#include <map>
+
+static std::map<int, std::string> maps;
+
+void MapManager::initialize(const std::string &mapReferenceFile)
+{
+    maps.clear();
+
+    XML::Document doc(mapReferenceFile);
+    xmlNodePtr rootNode = doc.rootNode();
+
+    if (!rootNode || !xmlStrEqual(rootNode->name, BAD_CAST "maps"))
+    {
+        LOG_ERROR("Map Manager: Error while parsing map database ("
+                  << mapReferenceFile << ")!");
+        return;
+    }
+    LOG_INFO("Loading map reference: " << mapReferenceFile);
+    for_each_xml_child_node(node, rootNode)
+    {
+        if (!xmlStrEqual(node->name, BAD_CAST "map"))
+            continue;
+
+        int id = XML::getProperty(node, "id", 0);
+        std::string name = XML::getProperty(node, "servername", std::string());
+
+        if (id > 0)
+            maps[id] = name;
+    }
+}
+
+std::map<int, std::string> &MapManager::getMaps()
+{
+    return maps;
+}

--- a/src/account-server/mapmanager.h
+++ b/src/account-server/mapmanager.h
@@ -1,0 +1,42 @@
+/*
+ *  The Mana Server
+ *  Copyright (C) 2004-2010  The Mana World Development Team
+ *  Copyright (C) 2010-2013  The Mana Development Team
+ *
+ *  This file is part of The Mana Server.
+ *
+ *  The Mana Server is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  any later version.
+ *
+ *  The Mana Server is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with The Mana Server.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MAPMANAGER_H
+#define MAPMANAGER_H
+
+#include <string>
+#include <map>
+
+namespace MapManager
+{
+    /**
+     * Loads map reference file
+     */
+    void initialize(const std::string &mapReferenceFile);
+
+    /**
+     * Returns a map of all maps
+     * @return a map of mapid + name of reserved server.
+     */
+    std::map<int, std::string> &getMaps();
+}
+
+#endif // MAPMANAGER_H

--- a/src/common/defines.h
+++ b/src/common/defines.h
@@ -29,6 +29,18 @@
 // World tick time in miliseconds.
 #define WORLD_TICK_MS 100
 
+// Files
+#define DEFAULT_MAPSDB_FILE                 "maps.xml"
+#define DEFAULT_ITEMSDB_FILE                "items.xml"
+#define DEFAULT_EQUIPDB_FILE                "equip.xml"
+#define DEFAULT_SKILLSDB_FILE               "skills.xml"
+#define DEFAULT_ATTRIBUTEDB_FILE            "attributes.xml"
+#define DEFAULT_MONSTERSDB_FILE             "monsters.xml"
+#define DEFAULT_STATUSDB_FILE               "status-effects.xml"
+#define DEFAULT_PERMISSION_FILE             "permissions.xml"
+#define DEFAULT_SPECIALSDB_FILE             "specials.xml"
+#define DEFAULT_EMOTESDB_FILE               "emotes.xml"
+
 /**
  * Exit value codes are thrown back at servers exit to reflect their exit state.
  */

--- a/src/common/manaserv_protocol.h
+++ b/src/common/manaserv_protocol.h
@@ -250,7 +250,7 @@ enum {
     PCMSG_KICK_USER                   = 0x0466, // W channel id, S name
 
     // Inter-server
-    GAMSG_REGISTER              = 0x0500, // S address, W port, S password, D items db revision, { W map id }*
+    GAMSG_REGISTER              = 0x0500, // S address, W port, S password, D items db revision
     AGMSG_REGISTER_RESPONSE     = 0x0501, // W item version, W password response, { S globalvar_key, S globalvar_value }
     AGMSG_ACTIVE_MAP            = 0x0502, // W map id, W Number of mapvar_key mapvar_value sent, { S mapvar_key, S mapvar_value }, W Number of map items, { D item Id, W amount, W posX, W posY }
     AGMSG_PLAYER_ENTER          = 0x0510, // B*32 token, D id, S name, serialised character data

--- a/src/game-server/accountconnection.cpp
+++ b/src/game-server/accountconnection.cpp
@@ -77,6 +77,8 @@ bool AccountConnection::start(int gameServerPort)
 
     LOG_INFO("Connection established to the account server.");
 
+    const std::string gameServerName =
+        Configuration::getValue("net_gameServerName", "server1");
     const std::string gameServerAddress =
         Configuration::getValue("net_publicGameHost",
                                 Configuration::getValue("net_gameHost",
@@ -84,18 +86,13 @@ bool AccountConnection::start(int gameServerPort)
     const std::string password =
         Configuration::getValue("net_password", "changeMe");
 
-    // Register with the account server and send the list of maps we handle
+    // Register with the account server
     MessageOut msg(GAMSG_REGISTER);
+    msg.writeString(gameServerName);
     msg.writeString(gameServerAddress);
     msg.writeInt16(gameServerPort);
     msg.writeString(password);
     msg.writeInt32(itemManager->getDatabaseVersion());
-    const MapManager::Maps &m = MapManager::getMaps();
-    for (MapManager::Maps::const_iterator i = m.begin(), i_end = m.end();
-            i != i_end; ++i)
-    {
-        msg.writeInt16(i->first);
-    }
     send(msg);
 
     // initialize sync buffer

--- a/src/game-server/main-game.cpp
+++ b/src/game-server/main-game.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "common/configuration.h"
+#include "common/defines.h"
 #include "common/permissionmanager.h"
 #include "common/resourcemanager.h"
 #include "game-server/accountconnection.h"
@@ -64,19 +65,8 @@
 
 using utils::Logger;
 
-// Default options that automake should be able to override.
 #define DEFAULT_LOG_FILE                    "manaserv-game.log"
-#define DEFAULT_ITEMSDB_FILE                "items.xml"
-#define DEFAULT_EQUIPDB_FILE                "equip.xml"
-#define DEFAULT_SKILLSDB_FILE               "skills.xml"
-#define DEFAULT_ATTRIBUTEDB_FILE            "attributes.xml"
-#define DEFAULT_MAPSDB_FILE                 "maps.xml"
-#define DEFAULT_MONSTERSDB_FILE             "monsters.xml"
-#define DEFAULT_STATUSDB_FILE               "status-effects.xml"
-#define DEFAULT_PERMISSION_FILE             "permissions.xml"
 #define DEFAULT_MAIN_SCRIPT_FILE            "scripts/main.lua"
-#define DEFAULT_SPECIALSDB_FILE             "specials.xml"
-#define DEFAULT_EMOTESDB_FILE               "emotes.xml"
 
 static int const WORLD_TICK_SKIP = 2; /** tolerance for lagging behind in world calculation) **/
 


### PR DESCRIPTION
If you set net_gameServerName you can now reserve maps in the maps.xml.
There you have to add the servername - property to the <map> tag.
Then the map will only be activated by that server.

Also changed the activate sequence that the account server now tells the game
server what maps to activate (previously the server requested all maps and the
account server said yes or no).

TODO: Fix general inter server map switching.

**Old patch. I did not changed it and i did not even looked at it in full depth. See this pullrequest as a discussion about the way the patch works.**
