### PR TITLE
Fixed undefined #defines in mingw and c++0x

### DIFF
--- a/libs/enet/include/enet/enet.h
+++ b/libs/enet/include/enet/enet.h
@@ -12,7 +12,7 @@ extern "C"
 
 #include <stdlib.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #include "enet/win32.h"
 #else
 #include "enet/unix.h"

--- a/src/game-server/collisiondetection.cpp
+++ b/src/game-server/collisiondetection.cpp
@@ -27,6 +27,9 @@
 
 #define D_TO_R 0.0174532925    // PI / 180
 #define R_TO_D 57.2957795      // 180 / PI
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
 
 // Tests to see if pos is between s1 degree and s2
 #define test_degrees(pos,s1,s2) (pos > s1 && pos < s2) || (s1 > s2 && !(pos < s1 && pos > s2))

--- a/src/utils/mathutils.cpp
+++ b/src/utils/mathutils.cpp
@@ -25,6 +25,10 @@
 #include <string.h>
 #include <float.h>
 
+#ifndef M_PI_2
+#define M_PI_2 1.57079632679489661923
+#endif
+
 static const int MATH_UTILS_MAX_ANGLE = 360;
 
 static float sinList[MATH_UTILS_MAX_ANGLE];


### PR DESCRIPTION
It looks like mingw does not define all the stuff in c++0x it does
without.
