### PR TITLE
Made member function tables available as a globals

### DIFF
--- a/example/scripts/maps/desert.lua
+++ b/example/scripts/maps/desert.lua
@@ -79,8 +79,8 @@ function Harmony(npc, ch, list)
     --- Give the player 100 units of money the first time.
     if  harmony_have_talked_to_someone == false then
         say("Here is some money for you to find some toys to play with.\nEh Eh!")
-        chr_money_change(ch, 100)
-        say(string.format("You now have %d shiny coins!", chr_money(ch)))
+        ch:change_money(100)
+        say(string.format("You now have %d shiny coins!", ch:money()))
         harmony_have_talked_to_someone = true
         say(string.format("Try to come back with a better level than %i.", ch:level()))
     else

--- a/example/scripts/npcs/banker.lua
+++ b/example/scripts/npcs/banker.lua
@@ -37,16 +37,16 @@ function Banker(npc, ch)
         result = 1
         while (result < 3) do --While they've choosen a valid option that isn't "Never mind"
             account = tonumber(chr_get_quest(ch, "BankAccount")) --Why do I need to convert this?
-            say("Your balance: " .. account .. ".\nYour money: " .. chr_money(ch) .. ".")
+            say("Your balance: " .. account .. ".\nYour money: " .. ch:money() .. ".")
             result = ask("Deposit", "Withdraw", "Never mind")
             if (result == 1) then --Deposit
-                money = chr_money(ch);
+                money = ch:money();
                 if (money > 0) then --Make sure they have money to deposit
                     say("How much would you like to deposit? (0 will cancel)")
-                    input = ask_integer(0, money, 1)
-                    money = chr_money(ch)
+                    input = ask_number(0, money, 1)
+                    money = ch:money()
                     if (input > 0 and input <= money) then --Make sure something weird doesn't happen and they try to deposit more than they have
-                        chr_money_change(ch, -input)
+                        ch:change_money(-input)
                         chr_set_quest(ch, "BankAccount", account + input)
                         say(input .. " GP deposited.")
                     elseif (input > money) then --Chosen more than they have
@@ -58,9 +58,9 @@ function Banker(npc, ch)
             elseif (result == 2) then --Withdraw
                 if (account > 0) then --Make sure they have money to withdraw
                     say("How much would you like to withdraw? (0 will cancel)")
-                    input = ask_integer(0, account, 1)
+                    input = ask_number(0, account, 1)
                     if (input > 0 and input <= account) then --Make sure something weird doesn't happen and they try to withdraw more than they have
-                        chr_money_change(ch, input)
+                        ch:change_money(input)
                         chr_set_quest(ch, "BankAccount", account - input)
                         say(input .. " GP withdrawn.")
                     elseif (input > account) then --Chosen more than they have

--- a/example/scripts/npcs/debugger.lua
+++ b/example/scripts/npcs/debugger.lua
@@ -50,8 +50,8 @@ function npc1_talk(npc, ch)
     end
 
   elseif v == 3 then
-    if chr_money_change(ch, -100) then
-      say(string.format("Thank you for you patronage! You are left with %d GP.", chr_money(ch)))
+    if ch:change_money(-100) then
+      say(string.format("Thank you for you patronage! You are left with %d GP.", ch:money()))
       local g = tonumber(chr_get_quest(ch, "001_donation"))
       if not g then g = 0 end
       g = g + 100

--- a/scripts/lua/libmana.lua
+++ b/scripts/lua/libmana.lua
@@ -367,27 +367,27 @@ end
 
 -- Below are some convenience methods added to the engine API
 
---- LUA chr_money_change (inventory)
--- chr_money_change(handle character, int amount)
+--- LUA entity:change_money (inventory)
+-- entity:change_money(int amount)
 ---
--- Changes the money currently owned by ''character'' by ''amount''.
+-- Valid only for character entities.
+--
+-- Changes the money currently owned by this character by ''amount''.
 --
 -- **Warning:** Before reducing the money make sure to check if the character
--- owns enough money using chr_money.
-chr_money_change = function(ch, amount)
-  ch:set_base_attribute(ATTR_GP,
-                        ch:base_attribute(ATTR_GP) + amount)
+-- owns enough money using entity:money.
+function Entity:change_money(amount)
+  self:set_base_attribute(ATTR_GP, self:base_attribute(ATTR_GP) + amount)
 end
 
---- LUA chr_money (inventory)
--- chr_money(handle character)
+--- LUA entity:money (inventory)
+-- entity:money()
 ---
--- Changes the money currently owned by ''character'' by ''amount''.
+-- Valid only for character entities.
 --
--- **Warning:** Before reducing the money make sure to check if the character
--- owns enough money using chr_money.
-chr_money = function(ch)
-  return ch:base_attribute(ATTR_GP)
+-- Returns the money currently owned by this character.
+function Entity:money()
+    return self:base_attribute(ATTR_GP)
 end
 
 -- Register callbacks

--- a/src/scripting/luautil.h
+++ b/src/scripting/luautil.h
@@ -106,6 +106,11 @@ public:
 #else
         luaL_setfuncs(s, members, 0);
 #endif
+
+        // Make the functions table available as a global
+        lua_pushvalue(s, -1);                   // metatable, "__index", {}, {}
+        lua_setglobal(s, mTypeName);            // metatable, "__index", {}
+
         lua_rawset(s, -3);                      // metatable
         lua_pop(s, 1);                          // -empty-
     }


### PR DESCRIPTION
This way the scripts can add or replace existing member functions, which can be useful. As demonstration chr_money and chr_money_change are now added as Entity.money and Entity.change_money.

Also fixed the banker to use ask_number instead of ask_integer (I had decided to rename this and apparently forgot the banker).

Mantis-issue: 503
