### PR TITLE
Allow external ENet support and small tweak for OpenBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ SET(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/CMake/Modules)
 OPTION(WITH_SQLITE "Enable Sqlite support (used by default)" ON)
 OPTION(WITH_MYSQL "Enable MySQL support" OFF)
 OPTION(ENABLE_LUA "Enable Lua scripting support" ON)
+OPTION(ENABLE_EXTERNAL_ENET "Enable external ENet support" OFF)
 
 # Exclude Sqlite support if the MySQL support was asked.
 IF(WITH_MYSQL)
@@ -52,6 +53,11 @@ ELSE (WIN32)
     SET(PKG_BINDIR ${CMAKE_INSTALL_PREFIX}/bin)
 ENDIF (WIN32)
 
-ADD_SUBDIRECTORY(libs/enet)
+IF (ENABLE_EXTERNAL_ENET)
+    FIND_PACKAGE(ENet)
+ELSE (ENABLE_EXTERNAL_ENET)
+    ADD_SUBDIRECTORY(libs/enet)
+ENDIF (ENABLE_EXTERNAL_ENET)
+
 ADD_SUBDIRECTORY(scripts)
 ADD_SUBDIRECTORY(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,9 +17,15 @@ ENDIF()
 IF (POLICY CMP0015)
   CMAKE_POLICY(SET CMP0015 OLD)
 ENDIF()
-INCLUDE_DIRECTORIES("../libs/enet/include")
-LINK_DIRECTORIES("../libs/enet")
-SET(INTERNAL_LIBRARIES enet)
+
+IF (ENABLE_EXTERNAL_ENET)
+  INCLUDE_DIRECTORIES(${ENet_INCLUDE_DIR})
+  SET(OPTIONAL_LIBRARIES ${OPTIONAL_LIBRARIES} ${ENet_LIBRARY})
+ELSE (ENABLE_EXTERNAL_ENET)
+  INCLUDE_DIRECTORIES("../libs/enet/include")
+  LINK_DIRECTORIES("../libs/enet")
+  SET(INTERNAL_LIBRARIES enet)
+ENDIF (ENABLE_EXTERNAL_ENET)
 
 # enable rc-handling with mingw
 # most likely this part can be kicked out with some later cmake version

--- a/src/common/configuration.cpp
+++ b/src/common/configuration.cpp
@@ -30,7 +30,11 @@
 #include "utils/xml.h"
 #include "utils/string.h"
 
+#if defined __OpenBSD__
+#define DEFAULT_CONFIG_FILE       "/etc/manaserv.xml"
+#else
 #define DEFAULT_CONFIG_FILE       "manaserv.xml"
+#endif
 
 /**< Persistent configuration. */
 static std::map< std::string, std::string > options;


### PR DESCRIPTION
Hi --

I'm an OpenBSD dev looking to port mana client and server (I already maintain the manaplus client for OpenBSD).

Here's a patch for manaserv that allows you to build with an ENet already installed on the system. On OpenBSD, we  prefer this to building internal libs, to reduce the amount of work needed to be done.

Also a small tweak for OpenBSD, as we place config files in /etc and not in the directory the binary is located in (which is /usr/local/bin).
